### PR TITLE
Handle negative amount in transactions #6347

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,build,dist,upload.py,doc,scripts,sele
 
 ignore=E126
 
-max-complexity=11
+max-complexity=12
 max-line-length=80

--- a/transaction.py
+++ b/transaction.py
@@ -152,6 +152,10 @@ class AuthorizeNetTransaction:
             self.state = 'failed'
             self.save()
             TransactionLog.serialize_and_create(self, exc.full_response)
+        except AuthorizeInvalidError, exc:
+            self.state = 'failed'
+            self.save()
+            TransactionLog.serialize_and_create(self, unicode(exc))
         else:
             self.state = 'authorized'
             self.provider_reference = str(result.transaction_response.trans_id)
@@ -175,6 +179,10 @@ class AuthorizeNetTransaction:
             self.state = 'failed'
             self.save()
             TransactionLog.serialize_and_create(self, exc.full_response)
+        except AuthorizeInvalidError, exc:
+            self.state = 'failed'
+            self.save()
+            TransactionLog.serialize_and_create(self, unicode(exc))
         else:
             self.state = 'completed'
             self.provider_reference = str(result.transaction_response.trans_id)
@@ -249,6 +257,10 @@ class AuthorizeNetTransaction:
             self.state = 'failed'
             self.save()
             TransactionLog.serialize_and_create(self, exc.full_response)
+        except AuthorizeInvalidError, exc:
+            self.state = 'failed'
+            self.save()
+            TransactionLog.serialize_and_create(self, unicode(exc))
         else:
             self.state = 'completed'
             self.provider_reference = str(result.transaction_response.trans_id)


### PR DESCRIPTION
An AuthorizeInvalidError is raised when amount is negative, so
instead of raising it, we log it in transaction.
